### PR TITLE
Add batch mode and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# IDE settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ Use `-h` to show more options and display help.\
 `-polaffini 1` indicates that POLAFFINI is performed.\
 `-omit_labs 2 41` will omit those labels for POLAFFINI as they are too big (whole left and right white matter) so taking their centroids is a bit meaningless.
 
+To register multiple images to the same template, place all your moving images in the same directory and pass the path to the directory as the `-m` option. If initialising with POLAFFINI, place the segmentation files in a separate directory, taking care to give each segmentation file the same filename as its corresponding image file:
+```
+img
+ | - scan1.nii.gz
+ | - scan2.nii.gz
+ \ - ...
+seg
+ | - scan1.nii.gz
+ | - scan2.nii.gz
+ \ - ...
+```
+
+Once the directory structure has been set up, pass the path to the segmentations directory as the `-ms` option. All output paths should also point to an existing directory, where the output files will be saved with the same name as their corresponding input image:
+```bash
+python scripts/register.py -m <path-to-moving-images-directory> \
+                           -ms <path-to-moving-segmentations-directory> \
+                           -rs <path-to-target-segmentation> \
+                           -oi <path-to-output-moved-images-directory>
+```
    
 ## 2. Training a new registration model from scratch
 

--- a/dwarp/utils.py
+++ b/dwarp/utils.py
@@ -56,18 +56,21 @@ def plot_losses(loss_file, is_val=False):
     if is_val:
         nb_losses = int(nb_losses / 2)
     
-    f, axs = plt.subplots(1,nb_losses); f.dpi = 200
+    f, axs = plt.subplots(1, nb_losses, figsize=(20,5))
+    f.dpi = 200
     plt.rcParams['font.size'] = '3'
     plt.rcParams["xtick.major.size"] = 2
     plt.rcParams["ytick.major.size"] = 2
     
     for l in range(nb_losses):
-        axs[l].plot(tab_loss.epoch, tab_loss.loc[:,tab_loss.columns[l+1]], linewidth=0.5) 
+        axs[l].plot(tab_loss.epoch, tab_loss.loc[:,tab_loss.columns[l+1]], linewidth=0.5, label="training")
         if is_val:
-            axs[l].plot(tab_loss.epoch, tab_loss.loc[:,tab_loss.columns[nb_losses+l+1]], linewidth=0.5) 
-        axs[l].set_title(tab_loss.columns[l+1], fontsize=6)
+            axs[l].plot(tab_loss.epoch, tab_loss.loc[:,tab_loss.columns[nb_losses+l+1]], linewidth=0.5, label="validation")
+        axs[l].set_title(tab_loss.columns[l+1], fontsize=12)
+        axs[l].legend(prop={'size': 10})
     
-    plt.show()
+    plt.tight_layout()
+    plt.savefig("./losses.png")
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dwarp = [
       "matplotlib==3.7.2",
       "neurite==0.2",
       "pandas==2.0.3",
-      "tensorflow==2.15.0",
+      "tensorflow[and-cuda]==2.15.1",
       "voxelmorph==0.2"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ numpy==1.24.3
 pandas==2.0.3
 scipy==1.12.0
 SimpleITK==2.3.1
-tensorflow==2.15.0
+tensorflow[and-cuda]==2.15.1
 voxelmorph==0.2
 nibabel==5.2.0

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -159,8 +159,7 @@ hist = model.fit(gen_train,
                  callbacks=[save_callback, csv_logger],
                  verbose=1)
 
-utils.plot_losses(args.model[:-3] + '_losses.csv', is_val=args.val_data is not None)
+dwarp.utils.plot_losses(args.model[:-3] + '_losses.csv', is_val=args.val_data is not None)
 
 
 
-    


### PR DESCRIPTION
The main change in this PR is adapting the registration script to accept a whole directory of images and segmentations as input. This significantly speeds up registration if multiple images are being registered to the same template, as the script doesn't have to reload the same Tensorflow libraries and model (and template files) for every image.

Additionally, the PR fixes a crash when plotting losses at the end of training and changes the PIP requirements to install all CUDA dependencies required for training. Each commit fixes a different issue, see their description for more info.

It may also be helpful to ignore whitespace when reviewing these changes.